### PR TITLE
gomod: Update Go version to 1.24.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/bchutil
 
-go 1.19
+go 1.24.3
 
 require (
 	github.com/btcsuite/btcd v0.24.2


### PR DESCRIPTION
## Changed
- Updated `go` directive in go.mod from `go 1.19` to `go 1.24.3`

## Rationale
- Go 1.24.3 is the latest patch release of Go 1.24
- This ensures the project can update to other libraries that declare _their_ minimum version as 1.24
- Aligns with other Luno repositories that are already using Go 1.24.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Go module version to 1.24.3 for improved compatibility and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->