### PR TITLE
chore: bump go.mod to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/bchutil
 
-go 1.25.0
+go 1.26.0
 
 toolchain go1.26.1
 


### PR DESCRIPTION
Bump the `go` directive in `go.mod` to `1.26.0`. The `toolchain go1.26.1` line is retained.